### PR TITLE
[API-596] Fix the C++ Dockerfile not building problem and update the C++ client version

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -16,15 +16,15 @@
 cmake_minimum_required(VERSION 3.10)
 
 project(hazelcast-cpp-kubernetes-example
-        VERSION 1.0.0
+        VERSION 1.0.1
         LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(hazelcastcxx REQUIRED)
+find_package(hazelcast-cpp-client REQUIRED)
 
 add_executable(cpp_client Client.cpp)
 
-target_link_libraries(cpp_client PRIVATE hazelcast::hazelcastcxx)
+target_link_libraries(cpp_client PRIVATE hazelcast-cpp-client::hazelcast-cpp-client)
 

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -5,7 +5,7 @@ ARG VERSION=4.1.1
 RUN dnf install -y gcc-c++ tar make wget bzip2 unzip cmake which boost-devel
 
 # install hazelcast cpp client
-RUN wget --quiet https://github.com/hazelcast/hazelcast-cpp-client/archive/v4.1.1.zip && unzip v4.1.1.zip && rm v4.1.1.zip && cd hazelcast-cpp-client-4.1.1 && cmake -S . -B build && cmake --build build --parallel --verbose && cmake --install build && cd .. && rm -rf hazelcast-cpp-client-4.1.1
+RUN wget --quiet https://github.com/hazelcast/hazelcast-cpp-client/archive/v4.1.1.zip && unzip -q v4.1.1.zip && rm v4.1.1.zip && cd hazelcast-cpp-client-4.1.1 && cmake -S . -B build && cmake --build build --verbose && cmake --install build && cd .. && rm -rf hazelcast-cpp-client-4.1.1
 
 # build client application
 COPY . .

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -2,13 +2,10 @@ FROM fedora:34
 
 ARG VERSION=4.1.1
 
-RUN dnf install -y gcc-c++ tar make wget bzip2 unzip cmake which
-
-# install boost
-RUN wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2 && tar xjf boost_1_76_0.tar.bz2 && rm boost_1_76_0.tar.bz2 && cd boost_1_76_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_76_0
+RUN dnf install -y gcc-c++ tar make wget bzip2 unzip cmake which boost-devel
 
 # install hazelcast cpp client
-RUN wget --quiet https://github.com/hazelcast/hazelcast-cpp-client/archive/v4.1.1.zip && unzip v4.1.1.zip && rm v4.1.1.zip && cd hazelcast-cpp-client-4.1.1 && cmake -S . -B build && cmake --build build --verbose && cmake --install build && cd .. && rm -rf hazelcast-cpp-client-4.1.1
+RUN wget --quiet https://github.com/hazelcast/hazelcast-cpp-client/archive/v4.1.1.zip && unzip v4.1.1.zip && rm v4.1.1.zip && cd hazelcast-cpp-client-4.1.1 && cmake -S . -B build && cmake --build build --parallel --verbose && cmake --install build && cd .. && rm -rf hazelcast-cpp-client-4.1.1
 
 # build client application
 COPY . .

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -1,20 +1,14 @@
-FROM fedora:22
+FROM fedora:34
 
-ARG VERSION=4.0.0
+ARG VERSION=4.1.1
 
-RUN dnf groups install -y "Development Tools"
-RUN dnf install -y gcc-c++ tar wget bzip2 unzip cmake which
-
-RUN wget --quiet https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-Linux-x86_64.sh && \
-    chmod +x ./cmake-3.19.0-Linux-x86_64.sh && \
-    ./cmake-3.19.0-Linux-x86_64.sh --prefix=/usr/local/ --exclude-subdir && \
-    rm cmake-3.19.0-Linux-x86_64.sh
+RUN dnf install -y gcc-c++ tar make wget bzip2 unzip cmake which
 
 # install boost
-RUN wget --quiet https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2 && tar xjf boost_1_75_0.tar.bz2 && rm boost_1_75_0.tar.bz2 && cd boost_1_75_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_75_0
+RUN wget --quiet https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2 && tar xjf boost_1_76_0.tar.bz2 && rm boost_1_76_0.tar.bz2 && cd boost_1_76_0 && ./bootstrap.sh && ./b2 address-model=64 --with-thread --with-chrono install && cd .. && rm -rf boost_1_76_0
 
 # install hazelcast cpp client
-RUN wget --quiet https://github.com/hazelcast/hazelcast-cpp-client/archive/v4.0.0.zip && unzip v4.0.0.zip && rm v4.0.0.zip && cd hazelcast-cpp-client-4.0.0 && cmake -S . -B build && cmake --build build --verbose && cmake --install build && cd .. && rm -rf hazelcast-cpp-client-4.0.0
+RUN wget --quiet https://github.com/hazelcast/hazelcast-cpp-client/archive/v4.1.1.zip && unzip v4.1.1.zip && rm v4.1.1.zip && cd hazelcast-cpp-client-4.1.1 && cmake -S . -B build && cmake --build build --verbose && cmake --install build && cd .. && rm -rf hazelcast-cpp-client-4.1.1
 
 # build client application
 COPY . .


### PR DESCRIPTION
Updated the docker C++ client version to 4.1.1, updated the k8s application version to 1.0.1, updated the fedora version, removed the cmake source install. No need to install the whole `Development Tools` but just the ones needed for C++ installation.

fix for [API-596](https://hazelcast.atlassian.net/browse/API-596)